### PR TITLE
Add support for auto-translating Windows path(s) to WSL path(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docker Compose WSL
-Use Docker Compose from your Windows Subsystem for Linux (WSL) distribution from PyCharm on Windows
+Use Docker Compose from your Windows Subsystem for Linux (WSL) distribution from an IDE that integrate Docker Compose like PyCharm on Windows
 
-This tool will translate Windows paths, used by the PyCharm IDE, to WSL paths, including the path(s) passed by PyCharm to the docker-compose binary, but also inside the PyCharm docker-compose override file.
+This tool will translate the Windows path(s) passed to the docker-compose binary, but also the one(s) inside the docker-compose file(s) passed as argument(s).
 
 ## Download
 
@@ -16,7 +16,7 @@ The latest binary can be found on the [release page](https://github.com/stashfil
 
 ## Remarks
 
-The initial 0.1 release is rough and only support translating the C:\ drive to the /c path inside WSL, but I plan to add support for allowing any drive to be mapped to any WSL path(s), using a YAML configuration file.
+This tool should work with any IDE that use the docker-compose command-line tool, but was only tested with PyCharm
 
 ## Build from source
 

--- a/docker-compose-wsl.py
+++ b/docker-compose-wsl.py
@@ -3,18 +3,12 @@ import os
 import sys
 import subprocess
 import pathlib
-
-# 3rd party libraries
-# import yaml
+import re
 
 # Variable(s)
-pycharm_compose_override = sys.argv[4] if len(sys.argv) > 3 else ''
-default_config = {
-    'wsl_drive_map': {
-        'C': '/c'
-    }
-}
-docker_compose_cli_args = ' '.join(sys.argv[1:])
+compose_file_tmp_dir = os.path.join(os.path.expandvars('%userprofile%'), 'AppData', 'Local', 'Temp')
+cli_args = sys.argv[1:]
+docker_compose_cli_args = ''
 bash_variables = ''
 
 # Function(s)
@@ -22,49 +16,73 @@ def wsl_drive_map(string_to_map):
     '''
     Replace all the instance of the drive(s) letter(s) to their corresponding WSL mount point
 
-    :param string_to_map:
+    :param path:
     :return:
     '''
+    mapped_string = string_to_map
 
-    for win_drive, wsl_mount in default_config.get('wsl_drive_map').items():
-        win_drive = win_drive.upper()
-        wsl_mount = '{0}/'.format(wsl_mount) if wsl_mount[-1] != '/' else wsl_mount
+    paths_regex = re.compile(r'([A-Za-z]+:[\\|/|\\\\][^:]+)')
+    for windows_path_match in re.finditer(paths_regex, string_to_map):
+        windows_path = windows_path_match.group(1)
 
-        string_to_map = string_to_map \
-            .replace('{0}:\\'.format(win_drive), wsl_mount) \
-            .replace('{0}:/'.format(win_drive), wsl_mount)
+        if os.path.exists(windows_path):
+            drives_regex = re.compile(r'([A-Za-z]+):[\\|/|\\\\]')
 
-    string_to_map = string_to_map.replace('\\', '/')
+            for drive in re.finditer(drives_regex, windows_path):
+                windows_drive = drive.group(1)
+                wsl_mount = '/{0}/'.format(windows_drive.lower())
 
-    return string_to_map
+                mapped_string = re.sub(r'{0}:[\\|/|\\\\]'.format(windows_drive), wsl_mount, mapped_string)
+                mapped_string = mapped_string.replace('\\', '/').replace('\\\\', '/')
+
+    return mapped_string
 
 # Add the docker variable(s), defined in the Windows environment variable(s) to the docker-compose command
 for key, value in os.environ.items():
     if key.startswith('DOCKER'):
+
+        try:
+            value = int(value)
+        except ValueError:
+            pass
+
         if isinstance(value, int):
             bash_variables += '{0}={1} '.format(key, value)
         else:
-            bash_variables += '{0}="{1}"'.format(key, value)
+            bash_variables += '{0}="{1}" '.format(key, value)
 
-# Replace the PyCharm command line option(s) Windows path with WSL path(s)
-docker_compose_cli_args = wsl_drive_map(docker_compose_cli_args)
-cli_args = ['C:\\Windows\\System32\\bash.exe', '-c', '{0} docker-compose {1}'.format(
+# Replace Windows path with WSL supported path
+for idx, cli_arg in enumerate(cli_args):
+
+    if idx != 0 and cli_args[idx - 1] == '-f':
+        compose_file = cli_arg
+        compose_file_name = os.path.basename(compose_file)
+        tmp_compose_file = os.path.join(compose_file_tmp_dir, compose_file_name)
+
+        if os.path.isfile(compose_file):
+            compose_file_content = pathlib.Path(compose_file).read_text()
+            new_compose_file_content = wsl_drive_map(compose_file_content)
+            pathlib.Path(tmp_compose_file).write_text(new_compose_file_content)
+        else:
+            sys.stderr.write('The PyCharm docker-compose file "{0}" does not exists, exiting...'.format(
+                compose_file))
+            raise SystemExit(1)
+
+        compose_file_mapped = wsl_drive_map(tmp_compose_file)
+        docker_compose_cli_args += '{0} '.format(compose_file_mapped)
+
+    else:
+        docker_compose_cli_args += '{0} '.format(cli_arg)
+
+docker_compose_cmd = ['C:\\Windows\\System32\\bash.exe', '-c', '{0} docker-compose {1}'.format(
         bash_variables,
         docker_compose_cli_args
     )
 ]
 
-# Replace Windows path with WSL supported path
-if os.path.isfile(pycharm_compose_override):
-    pycharm_override_content = pathlib.Path(pycharm_compose_override).read_text()
-    new_pycharm_override = wsl_drive_map(pycharm_override_content)
-    pathlib.Path(pycharm_compose_override).write_text(new_pycharm_override)
-else:
-    sys.stderr.write('The PyCharm docker-compose override file "{0}" does not exists, exiting...'.format(
-        pycharm_compose_override))
-    raise SystemExit(1)
-
-print('The docker-compose argument(s) were: {0}'.format(bash_variables))
+print('The docker-compose bash variable(s) were: {0}'.format(bash_variables))
+print('The docker-compose argument(s) were: {0}'.format(docker_compose_cli_args))
+print('The docker-compose command was: {0}'.format(' '.join(docker_compose_cmd)))
 
 # Run the docker-compose binary in bash on WSL with the appropriate argument(s)
-subprocess.run(cli_args, shell=True)
+subprocess.run(docker_compose_cmd, shell=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-pyaml
 pyinstaller


### PR DESCRIPTION
Add support for auto-translating Windows path(s) passed to the Docker Compose binary and Windows path(s) inside the Docker Compose file(s), for all Windows drive(s)